### PR TITLE
Bintray sunset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8-jre-alpine
 LABEL maintainer="andrea.fiore@lenses.io"
 
 ARG RELEASE=2.13.2
-ARG ALLURE_REPO=https://dl.bintray.com/qameta/maven/io/qameta/allure/allure-commandline
+ARG ALLURE_REPO=https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline
 
 RUN apk update 
 RUN apk add bash 


### PR DESCRIPTION
[Bintray is being shut down on 1st May 2021](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)

Change the `ALLURE_REPO` URL to point to Apache.org instead.

Fixes https://github.com/afiore/action-allure-report/issues/2